### PR TITLE
Evitando erro quando for atualizar o histórico da trasação.

### DIFF
--- a/pagseguro/models.py
+++ b/pagseguro/models.py
@@ -128,7 +128,7 @@ class TransactionHistory(models.Model):
     )
 
     def __str__(self):
-        '{0} - {1} - {2}'.format(
+        return '{0} - {1} - {2}'.format(
             self.transaction, self.status, self.date
         )
 


### PR DESCRIPTION
Ao clicar em um link de uma trasação lançava o seguinte erro:
TypeError at /admin/pagseguro/transaction/...
coercing to Unicode: need string or buffer, NoneType found
