### PR TITLE
Definindo um valor padrão para Booleano

### DIFF
--- a/pagseguro/models.py
+++ b/pagseguro/models.py
@@ -39,7 +39,8 @@ class Checkout(models.Model):
     success = models.BooleanField(
         'Sucesso',
         db_index=True,
-        help_text='O checkout foi feito com sucesso?'
+        help_text='O checkout foi feito com sucesso?',
+        default=False
     )
 
     message = models.TextField(


### PR DESCRIPTION
Para evitar etse aviso quando executar a aplicação:

System check identified some issues:

WARNINGS:
pagseguro.Checkout.success: (1_6.W002) BooleanField does not have a default value.
    HINT: Django 1.6 changed the default value of BooleanField from False to None. See https://docs.djangoproject.com/en/1.6/ref/models/fields/#booleanfield for more information.
