### PR TITLE
base_params, params and itens devem ser variáveis de instância

### DIFF
--- a/pagseguro/api.py
+++ b/pagseguro/api.py
@@ -55,31 +55,30 @@ class PagSeguroApi(object):
     notification_url = NOTIFICATION_URL
     transaction_url = TRANSACTION_URL
 
-    itens = []
-    base_params = {
-        'email': PAGSEGURO_EMAIL,
-        'token': PAGSEGURO_TOKEN,
-        'currency': 'BRL',
-    }
-    params = {}
-
     def __init__(self, **kwargs):
+        self.base_params = {
+            'email': PAGSEGURO_EMAIL,
+            'token': PAGSEGURO_TOKEN,
+            'currency': 'BRL',
+        }
         self.base_params.update(kwargs)
+        
+        self.params = {}
+        self.items = []
 
     def add_item(self, item):
-        self.itens.append(item)
+        self.items.append(item)
 
     def get_items(self):
-        return self.itens
+        return self.items
 
     def clear_items(self):
-        self.itens = []
+        self.items = []
 
     def build_params(self):
-        self.params = {}
         self.params.update(self.base_params)
 
-        for index, item in enumerate(self.itens):
+        for index, item in enumerate(self.items):
             count = index + 1
             self.params['itemId{0}'.format(count)] = item.id
             self.params['itemDescription{0}'.format(count)] = item.description

--- a/pagseguro/tests/test_api.py
+++ b/pagseguro/tests/test_api.py
@@ -358,3 +358,21 @@ class PagSeguroApiTest(TestCase):
             data['transaction']['code'],
             '9E884542-81B3-4419-9A75-BCC6FB495EF1'
         )
+
+    def test_base_params_is_instance_variable(self):
+        # Regression test
+        api1 = PagSeguroApi()
+        api2 = PagSeguroApi()
+        self.assertIsNot(api1.base_params, api2.base_params)
+
+    def test_params_is_instance_variable(self):
+        # Regression test
+        api1 = PagSeguroApi()
+        api2 = PagSeguroApi()
+        self.assertIsNot(api1.params, api2.params)
+
+    def test_items_is_instance_variable(self):
+        # Regression test
+        api1 = PagSeguroApi()
+        api2 = PagSeguroApi()
+        self.assertIsNot(api1.items, api2.items)


### PR DESCRIPTION
`itens`, `base_params` e `params` estão como variáveis de classe. O comportamento esperado é que elas fossem variáveis de instância, já que `PagSeguroApi` é uma classe instanciável com métodos que alteram essas variáveis.

O fato dessas variáveis serem de classe causa um bug sutil: pode acontecer da variável de classe não ser resetada após o final do request (o Django não garante isso). Isso aconteceu comigo em um deployment simples com gunicorn. No meu caso, ao voltar para a página anterior ao checkout do PagSeguro e realizar outra compra, as duas compras se acumulavam no carrinho do PagSeguro, o que é um comportamento incorreto. A solução segue neste pull-request.
