### PR TITLE
Substituição de six.b por six.u na view de notificação

### DIFF
--- a/pagseguro/tests/test_views.py
+++ b/pagseguro/tests/test_views.py
@@ -105,8 +105,9 @@ class ReceiveNotificationViewTest(TestCase):
         )
 
         response = self.client.post(self.url, self.post_params)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, six.b('Notificação inválida.'))
+        self.assertContains(
+            response, six.u('Notificação inválida.'), status_code=400
+        )
 
     @httpretty.activate
     def test_render(self):
@@ -121,7 +122,8 @@ class ReceiveNotificationViewTest(TestCase):
         )
 
         response = self.client.post(self.url, self.post_params)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.content, six.b('Notificação recebida com sucesso.')
+        self.assertContains(
+            response,
+            six.u('Notificação recebida com sucesso.'),
+            status_code=200
         )

--- a/pagseguro/tests/test_views.py
+++ b/pagseguro/tests/test_views.py
@@ -105,9 +105,18 @@ class ReceiveNotificationViewTest(TestCase):
         )
 
         response = self.client.post(self.url, self.post_params)
-        self.assertContains(
-            response, six.u('Notificação inválida.'), status_code=400
-        )
+        self.assertEqual(response.status_code, 400)
+        if six.PY3:
+            self.assertContains(
+                response,
+                six.u('Notificação inválida.'),
+                status_code=400
+            )
+        else:
+            self.assertEqual(
+                response.content,
+                six.b('Notificação inválida.')
+            )
 
     @httpretty.activate
     def test_render(self):
@@ -122,8 +131,15 @@ class ReceiveNotificationViewTest(TestCase):
         )
 
         response = self.client.post(self.url, self.post_params)
-        self.assertContains(
-            response,
-            six.u('Notificação recebida com sucesso.'),
-            status_code=200
-        )
+        self.assertEqual(response.status_code, 200)
+        if six.PY3:
+            self.assertContains(
+                response,
+                six.u('Notificação recebida com sucesso.'),
+                status_code=200
+            )
+        else:
+            self.assertEqual(
+                response.content,
+                six.b('Notificação recebida com sucesso.')
+            )

--- a/pagseguro/views.py
+++ b/pagseguro/views.py
@@ -20,6 +20,10 @@ def receive_notification(request):
         response = pagseguro_api.get_notification(notification_code)
 
         if response.status_code == 200:
+            if six.PY2:
+                return HttpResponse(six.b('Notificação recebida com sucesso.'))
             return HttpResponse(six.u('Notificação recebida com sucesso.'))
 
+    if six.PY2:
+        return HttpResponse(six.b('Notificação inválida.'), status=400)
     return HttpResponse(six.u('Notificação inválida.'), status=400)

--- a/pagseguro/views.py
+++ b/pagseguro/views.py
@@ -20,6 +20,6 @@ def receive_notification(request):
         response = pagseguro_api.get_notification(notification_code)
 
         if response.status_code == 200:
-            return HttpResponse(six.b('Notificação recebida com sucesso.'))
+            return HttpResponse(six.u('Notificação recebida com sucesso.'))
 
-    return HttpResponse(six.b('Notificação inválida.'), status=400)
+    return HttpResponse(six.u('Notificação inválida.'), status=400)


### PR DESCRIPTION
Fix da issue que eu criei: https://github.com/allisson/django-pagseguro2/issues/7. Substituindo o six.b por six.u, não ocorreu problema no middleware e a resposta retornou com código 200.