### PR TITLE
permitir enviar itens para o pagseguro com valores menores que 1 real

### DIFF
--- a/pagseguro/forms.py
+++ b/pagseguro/forms.py
@@ -16,7 +16,7 @@ class PagSeguroItemForm(forms.Form):
     amount = forms.DecimalField(
         max_digits=9,
         max_value=9999999,
-        min_value=1,
+        min_value=0.001,
         decimal_places=2
     )
 
@@ -28,7 +28,7 @@ class PagSeguroItemForm(forms.Form):
     shipping_cost = forms.DecimalField(
         max_digits=9,
         max_value=9999999,
-        min_value=1,
+        min_value=0.001,
         decimal_places=2,
         required=False
     )


### PR DESCRIPTION
Olá Alison,
Tenho um cliente que vende produtos com valores menores que um real, 0,45 centavos por exemplo. Estou utilizando sua app para criar os pagamentos com o pagseguro e quando tento enviar o pagamento, o form PagSeguroItemForm nao permite porque o campo "amount" não aceita valores decimais menores que 1, mas vendo a documentação do pagseguro, vi que ele aceita valores decimais maiores que zero para este campo. Eu aproveitei e modifiquei o campo shipping_cost que também aceita valores decimais maiores que zero.  
Foi utilizado o valor 0.001 em vez de 0.01 para aceitar também valores igual a um centavo, mesmo sabendo que é dificil alguem vender algo por um centavo, rs, mas dessa forma fica aberto para todas as possibilidades. Valeuuuuu e obrigado por essa App.  