### PR TITLE
Ajuste no urls.py para compatibilidade com django 1.10

### DIFF
--- a/pagseguro/urls.py
+++ b/pagseguro/urls.py
@@ -2,11 +2,9 @@
 from __future__ import unicode_literals
 from django.conf.urls import patterns, url
 
-urlpatterns = patterns(
-    'pagseguro.views',
+from pagseguro.views import receive_notification
 
-    url(
-        r'^$', 'receive_notification', name='pagseguro_receive_notification'
-    ),
+urlpatterns = [
+    url(r'^$', receive_notification, name='pagseguro_receive_notification'),
+]
 
-)


### PR DESCRIPTION
RemovedInDjango110Warning: Support for string view arguments to url() is
deprecated and will be removed in Django 1.10 (got
receive_notification). Pass the callable instead.
  r'^$', 'receive_notification', name='pagseguro_receive_notification'