### PR TITLE
Corrigindo DeprecationWarning em chave estrangeira

### DIFF
--- a/pagseguro/models.py
+++ b/pagseguro/models.py
@@ -114,6 +114,7 @@ class TransactionHistory(models.Model):
 
     transaction = models.ForeignKey(
         Transaction,
+        on_delete=models.CASCADE,
         verbose_name='Transação'
     )
 


### PR DESCRIPTION
No Django 2.0 as `ForeignKey`s precisam de `on_delete`, o comportamento padrão no Django 1 é `CASCADE` então estou adicionando esse valor por default