### PR TITLE
Update for Django 3.X

### DIFF
--- a/pagseguro/models.py
+++ b/pagseguro/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 from pagseguro.settings import PAGSEGURO_LOG_IN_MODEL
 from pagseguro.signals import (


### PR DESCRIPTION
python_2_unicode_compatible dropped in django.utils.encoding starting from version 3.X